### PR TITLE
fix: align service property in catalog with DCAT spec

### DIFF
--- a/catalog/message/catalog.json
+++ b/catalog/message/catalog.json
@@ -8,7 +8,7 @@
   "dcat:keyword": [
     "traffic", "government"
   ],
-  "dcat:DataService": [
+  "dcat:service": [
     {
       "@id": "urn:uuid:4aa2dcc8-4d2d-569e-d634-8394a8834d77",
       "@type": "dcat:DataService",


### PR DESCRIPTION
According to [DCAT v3](https://www.w3.org/TR/vocab-dcat-3), a `dcat:Catalog` has a `dcat:service` of type `dcat:DataService`.