### PR TITLE
refactor: clean up

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-* [Introduction](./README.md)
+* [Dataspace Protocol v0.8](./README.md)
 * [Terminology](./model/terminology.md)
 * [Information Model](./model/model.md)
 

--- a/catalog/catalog.binding.https.md
+++ b/catalog/catalog.binding.https.md
@@ -50,14 +50,14 @@ request.
 
 #### 2.3.2 OK (200) Response
 
-If the request is successful, the catalog service must return a response body containing a [Catalog](./message/catalog.json) which is a profiled DCAT Catalog type
+If the request is successful, the catalog service must return a response body containing a [Catalog](./message/catalog.json) which is a profiled DCAT `Catalog` type
 described by the [Catalog Protocol Specification](catalog.protocol.md).
 
 ### 2.4 The `catalog/datasets/{id}` endpoint
 
 #### 2.3.1 GET
 
-The [DatasetRequestMessage](catalog.protocol.md#21-datasetrequestmessage) corresponds to `GET https://<base>/catalog/datasets/{id}}`:
+The [DatasetRequestMessage](catalog.protocol.md#24-datasetrequestmessage) corresponds to `GET https://<base>/catalog/datasets/{id}}`:
 
 ```
 GET https://provider.com/datasets/{id}
@@ -71,7 +71,7 @@ The `Authorization` header is optional if the catalog service does not require a
 
 #### 2.4.2 OK (200) Response
 
-If the request is successful, the catalog service must return a response body containing a [Dataset](./message/dataset.json) which is a DCAT Dataset type
+If the request is successful, the catalog service must return a response body containing a [Dataset](./message/dataset.json) which is a DCAT `Dataset` type
 described by the [Catalog Protocol Specification](catalog.protocol.md).
 
 ## 3 Technical Considerations
@@ -147,5 +147,5 @@ Authorization: ...
 }
 ```
 
-The `CatalogResponseMessage` would be POSTed back to the endpoint. the response message could be posted mutiple times for paginated results and would need to include the
+The `CatalogResponseMessage` would be POSTed back to the endpoint. the response message could be posted multiple times for paginated results and would need to include the
 original `@id` value as a `correlationId` and a property indicating if the contents are complete (or additional responses will be sent).

--- a/catalog/catalog.protocol.md
+++ b/catalog/catalog.protocol.md
@@ -59,7 +59,7 @@ be defined in the relevant catalog binding specification.
 The catalog contains all [Asset Entries](#31-asset-entry) which the requester shall see.
 
 
-### 2.3 Catalog Error Message
+### 2.3 CatalogErrorMessage
 
 ![](./message/diagram/catalog-error-message.png)
 
@@ -73,7 +73,7 @@ The catalog contains all [Asset Entries](#31-asset-entry) which the requester sh
 
 #### Description
 
-A Catalog Error Message is used when an error occured after a CatalogRequestMessage and the provider can not provide its catalog to the requester.
+A Catalog Error Message is used when an error occurred after a `CatalogRequestMessage` and the provider can not provide its catalog to the requester.
 
 ### 2.4 DatasetRequestMessage
 
@@ -115,10 +115,10 @@ target attributes. The target of an offer is the asset associated with the conta
 An asset may contain 0..N [DCAT Distributions](https://www.w3.org/TR/vocab-dcat-3/#Class:Distribution). Each distribution must have at least one `DataService` which specifies where
 the distribution is obtained. Specifically, a `DataService` specifies the endpoint for initiating a `ContractNegotiation` and `AssetTransfer`.
 
-A Distribution may have 0..N `hasPolicy` attributes that contain an ODRL `Offer` defining the usage control policy associated with the asset and this explicit Distribution.
+A Distribution may have 0..N `hasPolicy` attributes that contain an ODRL `Offer` defining the usage control policy associated with the asset and this explicit `Distribution`.
 Offers must NOT contain any target attributes. The target of an offer is the asset entry that contains the distribution.
 
-Support for `hasPolicy` attributes on a Distribution is optional. Implementations may choose not to support this feature, in which case they should return an appropriate error
+Support for `hasPolicy` attributes on a `Distribution` is optional. Implementations may choose not to support this feature, in which case they should return an appropriate error
 message to clients.
 
 ### 3.3 DataService

--- a/negotiation/contract.negotiation.binding.https.md
+++ b/negotiation/contract.negotiation.binding.https.md
@@ -15,7 +15,7 @@ The OpenAPI definitions for this specification can be accessed [here](TBD).
 
 2. All request and response messages must use the `application/json` media type.
 
-### 2.2 ContractNegotiationError
+### 2.2 Contract Negotiation Error
 
 In the event of a client request error, the connector must return an appropriate HTTP 4xxx client error code. If an error body is returned it must be
 a [ContractNegotiationError](./message/contract-negotiation-error.json) with the following properties:
@@ -29,7 +29,7 @@ a [ContractNegotiationError](./message/contract-negotiation-error.json) with the
 ### 2.2.1 State transition errors
 
 If a client or provider connector makes a request that results in an invalid contract negotiation state transition as defined by the Contract Negotiation Protocol, it must return
-an HTTP code 400 (Bad Request) with an NegotiationErrorMessage in the response body.
+an HTTP code 400 (Bad Request) with an `ContractNegotiationError` in the response body.
 
 ### 2.3 Authorization
 
@@ -146,7 +146,7 @@ A consumer connector can POST a [ContractNegotiationEventMessage](./message/cont
 provider contract offer. If the negotiation state is successfully transitioned, the provider must return HTTP code 200 (OK). The response body is not specified and clients are not
 required to process it.
 
-If the current contract offer was created by the consumer, the provider must return HTTP code 400 (Bad Request) with an NegotiationErrorMessage in the response body.
+If the current contract offer was created by the consumer, the provider must return HTTP code 400 (Bad Request) with an `NegotiationErrorMessage` in the response body.
 
 ### 2.8 The provider `negotiations/:id/agreement/verification` resource
 

--- a/negotiation/contract.negotiation.protocol.md
+++ b/negotiation/contract.negotiation.protocol.md
@@ -32,12 +32,12 @@ The CN states are:
 
 ### Contract Negotiation State Machine
 
-The CN state machine is represented in the following diagram. Note that transitions to the TERMINATED state may occur from any other state and are not shown for simplicity:
+The CN state machine is represented in the following diagram. Note that transitions to the `TERMINATED` state may occur from any other state and are not shown for simplicity:
 
 ![](./contract.negotiation.state.machine.png)
 
 Transitions marked with `C` indicate a message sent by the consumer, transitions marked with `P` indicate a provider message. Terminal states are final; the state machine may
-not transition to another state. A new CN may be initiated if, for instance, the CN entered the TERMINATED state due to a network issue.
+not transition to another state. A new CN may be initiated if, for instance, the CN entered the `TERMINATED` state due to a network issue.
 
 ## Message Types
 
@@ -69,7 +69,7 @@ The CN state machine is transitioned upon receipt and acknowledgement of a messa
 
 #### Description
 
-The _ContractRequestMessage_ is sent by a consumer to initiate a contract negotiation.
+The `ContractRequestMessage` is sent by a consumer to initiate a contract negotiation.
 
 #### Notes
 
@@ -103,7 +103,7 @@ The _ContractRequestMessage_ is sent by a consumer to initiate a contract negoti
 
 #### Description
 
-The _ContractOfferMessage_ is sent by a provider to initiate a contract negotiation.
+The `ContractOfferMessage` is sent by a provider to initiate a contract negotiation.
 
 
 ### 3. ContractAgreementMessage
@@ -122,11 +122,11 @@ The _ContractOfferMessage_ is sent by a provider to initiate a contract negotiat
 
 #### Description
 
-The _ContractAgreementMessage_ is sent by a provider when it agrees to a contract. It contains the complete contract agreement with the provider's signature.
+The `ContractAgreementMessage` is sent by a provider when it agrees to a contract. It contains the complete contract agreement with the provider's signature.
 
-A _ContractAgreementMessage_ must contain a `processId`.
+A `ContractAgreementMessage` must contain a `processId`.
 
-A _ContractAgreementMessage_ must contain an ODRL Agreement.
+A `ContractAgreementMessage` must contain an ODRL `Agreement`.
 
 ### 4. ContractAgreementVerificationMessage
 
@@ -145,10 +145,10 @@ A _ContractAgreementMessage_ must contain an ODRL Agreement.
 
 #### Description
 
-The _ContractAgreementVerificationMessage_ is sent by a consumer to verify the acceptance of a contract agreement. A provider responds with an error if the signature can't be
+The `ContractAgreementVerificationMessage` is sent by a consumer to verify the acceptance of a contract agreement. A provider responds with an error if the signature can't be
 validated or is incorrect.
 
-A _ContractAgreementVerificationMessage_ must contain a `processId`.
+A `ContractAgreementVerificationMessage` must contain a `processId`.
 
 ### 5. ContractNegotiationEventMessage
 
@@ -167,15 +167,15 @@ A _ContractAgreementVerificationMessage_ must contain a `processId`.
 
 #### Description
 
-When the _ContractNegotiationEventMessage_ is sent by a provider with an `eventType` property set to `FINALIZED`, a contract agreement has been finalized and the associated asset
-is accessible. The state machine is transitioned to the PROVIDER_FINALIZED state. Other event types may be defined in the future. A consumer responds with an error if the signature
+When the `ContractNegotiationEventMessage` is sent by a provider with an `eventType` property set to `FINALIZED`, a contract agreement has been finalized and the associated asset
+is accessible. The state machine is transitioned to the `PROVIDER_FINALIZED` state. Other event types may be defined in the future. A consumer responds with an error if the signature
 can't be validated or is incorrect.
 
-It is an error for a consumer to send a ContractNegotiationEventMessage with an eventType `finalized` to the provider.
+It is an error for a consumer to send a `ContractNegotiationEventMessage` with an eventType `finalized` to the provider.
 
-When the _ContractNegotiationEventMessage_ is sent by a consumer with an `eventType` set to  `ACCEPTED`, the state machine is placed in the CONSUMER_AGREED state.
+When the `ContractNegotiationEventMessage` is sent by a consumer with an `eventType` set to  `ACCEPTED`, the state machine is placed in the `CONSUMER_AGREED` state.
 
-It is an error for a provider to send a ContractNegotiationEventMessage with an eventType `ACCEPTED` to the consumer.
+It is an error for a provider to send a `ContractNegotiationEventMessage` with an eventType `ACCEPTED` to the consumer.
 
 Note that contract events are not intended for propagation of agreement state after a contract negotiation has entered a terminal state. It is considered an error for a consumer or
 provider to send a contract negotiation event after the negotiation state machine has entered a terminal state.
@@ -194,7 +194,7 @@ provider to send a contract negotiation event after the negotiation state machin
 
 #### Description
 
-The _ContractNegotiationTerminationMessage_ is sent by a consumer or provider indicating it has cancelled the negotiation sequence. The message can be sent at any state of a negotiation
+The `ContractNegotiationTerminationMessage` is sent by a consumer or provider indicating it has cancelled the negotiation sequence. The message can be sent at any state of a negotiation
 without providing an explanation. Nevertheless, the sender may provide a description to help the receiver.
 
 #### Notes
@@ -202,7 +202,7 @@ without providing an explanation. Nevertheless, the sender may provide a descrip
 - A contract negotiation may be terminated for a variety of reasons, for example, an unrecoverable error was encountered or one of the parties no longer wishes to continue. A
   connector's operator may remove terminated contract negotiation resources after it has reached the terminated state.
 
-- If an error is received in response to a ContractNegotiationTerminationMessage, the sending party may choose to ignore the error.
+- If an error is received in response to a `ContractNegotiationTerminationMessage`, the sending party may choose to ignore the error.
 
 ## ContractNegotiationError
 
@@ -216,11 +216,11 @@ without providing an explanation. Nevertheless, the sender may provide a descrip
 
 #### Description
 
-The _ContractNegotiationError_ is an object returned by a consumer or provider indicating an error has occurred. It does not cause a state transition.
+The `ContractNegotiationError` is an object returned by a consumer or provider indicating an error has occurred. It does not cause a state transition.
 
 #### Notes
 
-- A _ContractNegotiationError_ is different to an error response. A _ContractNegotiationError_ does not necessarily finish the negotiation but can continue
+- A `ContractNegotiationError` is different to an error response. A `ContractNegotiationError` does not necessarily finish the negotiation but can continue
   afterwards.
 
 ## Hash and Signature Calculations
@@ -237,7 +237,7 @@ Hash and Signatures are calculated as defined in the [[JWS/CT]](#references) of 
 
 - Adopt JWS/CT, an extension to the JSON Web Signature (JWS) standard.
 - Combines the detached mode of JWS with the JSON Canonicalization Scheme (JCS). Detached mode is when the payload section of the JWS is replaced
-  by an empty string:  XXXX.PAYLOAD.YYYY becomes XXXX..YYYY. Detached mode is described in the JWS spec.
+  by an empty string: `XXXX.PAYLOAD.YYYY` becomes `XXXX..YYYY`. Detached mode is described in the JWS spec.
 - Maintains Signed JSON data in JSON format.
 
 

--- a/negotiation/contract.negotiation.protocol.md
+++ b/negotiation/contract.negotiation.protocol.md
@@ -81,8 +81,6 @@ The `ContractRequestMessage` is sent by a consumer to initiate a contract negoti
 
 - The dataset id is not technically required but included to avoid an error where the offer is associated with a different data set.
 
-> Comment sba (20.12.2022): Let's use the `offer.target` property for this, and nothing else.
-
 - `callbackAddress` is a URL indicating where messages to the consumer should be sent in asynchronous settings. If the address is not understood, the provider MUST return an
   UNRECOVERABLE error.
 

--- a/negotiation/contract.negotiation.state.machine.puml
+++ b/negotiation/contract.negotiation.state.machine.puml
@@ -1,7 +1,7 @@
 @startuml "hub-request-processing"
 !pragma layout smetana
 
-!include ../diagrams/diagram.styles.puml
+!include ../common/style/diagram.styles.puml
 
 hide empty description
 

--- a/transfer/transfer-process-state-machine.puml
+++ b/transfer/transfer-process-state-machine.puml
@@ -1,7 +1,7 @@
 @startuml "transfer-process-state-machine"
 !pragma layout smetana
 
-!include ../../diagrams/diagram.styles.puml
+!include ../common/style/diagram.styles.puml
 
 hide empty description
 

--- a/transfer/transfer.process.binding.https.md
+++ b/transfer/transfer.process.binding.https.md
@@ -119,7 +119,7 @@ Note that if the location header is not an absolute URL, it must resolve to an a
 #### 2.6.1 POST
 
 The consumer connector can POST a [TransferStartMessage](./message/transfer-start-message.json) to attempt to start a transfer process after it has been suspended. If the transfer
-process state is successfully transitioned, the producer must return HTTP code 200 (OK). The response body is not specified and clients are not required to process it.
+process state is successfully transitioned, the provider must return HTTP code 200 (OK). The response body is not specified and clients are not required to process it.
 
 ### 2.7 The provider `transfers/:id/completion` resource
 
@@ -140,7 +140,7 @@ process state is successfully transitioned, the provider must return HTTP code 2
 #### 2.9.1 POST
 
 The consumer connector can POST a [TransferSuspensionMessage](./message/transfer-suspension-message.json) to suspend a transfer process. If the transfer
-process state is successfully transitioned, the producer must return HTTP code 200 (OK). The response body is not specified and clients are not required to process it.
+process state is successfully transitioned, the provider must return HTTP code 200 (OK). The response body is not specified and clients are not required to process it.
 
 ## 3 Consumer Callback Path Bindings
 

--- a/transfer/transfer.process.protocol.md
+++ b/transfer/transfer.process.protocol.md
@@ -26,8 +26,7 @@ receives counter-party messages and manages the TP state. The data plane perform
 planes.
 
 It is important to note that the control and data planes are logical constructs. Implementations may choose to deploy both components within a single process or across
-heterogeneous
-clusters.
+heterogeneous clusters.
 
 ### Asset Transfer Types
 
@@ -69,7 +68,7 @@ The TP states are:
 
 ## Message Types
 
-### 1. Transfer Request Message
+### 1. TransferRequestMessage
 
 ![](./message/diagram/transfer-request-message.png)
 
@@ -87,7 +86,7 @@ The TP states are:
 
 #### Description
 
-The _TransferRequestMessage_ is sent by a consumer to initiate a transfer process.
+The `TransferRequestMessage` is sent by a consumer to initiate a transfer process.
 
 #### Notes
 
@@ -96,21 +95,21 @@ The _TransferRequestMessage_ is sent by a consumer to initiate a transfer proces
 - The `dataAddress` property must only be provided if the `dct:format` requires a push transfer.
 - `callbackAddress` is a URI indicating where messages to the consumer should be sent. If the address is not understood, the provider MUST return an UNRECOVERABLE error.
 
-Providers should implement idempotent behavior for TransferRequestMessage based on the value of `@id`. Providers may choose to implement idempotent behavior for a certain period of
+Providers should implement idempotent behavior for `TransferRequestMessage` based on the value of `@id`. Providers may choose to implement idempotent behavior for a certain period of
 time. For example, until a transfer processes has completed and been archived after an implementation-specific expiration period. If a request for the given `@id` has already been
-received *and* the same consumer sent the original message, the provider should respond with an appropriate _DataAddressMessage_.
+received *and* the same consumer sent the original message, the provider should respond with an appropriate `DataAddressMessage`.
 
-Once a transfer process have been created, all associated callback messages must include a `correlationId` set to the _TransferRequestMessage_ `@id` value.
+Once a transfer process have been created, all associated callback messages must include a `correlationId` set to the `TransferRequestMessage` `@id` value.
 
-Providers must include a `correlationId` property in the `TransferProcessMessage` with a value set to the `@id` of the corresponding _TransferRequestMessage_
+Providers must include a `correlationId` property in the `TransferProcessMessage` with a value set to the `@id` of the corresponding `TransferRequestMessage`.
 
 #### Notes
 
-- The 'dataAddress' contains a transport-specific endpoint address for pushing the asset. It may include a temporary authorization token.
+- The `dataAddress` contains a transport-specific endpoint address for pushing the asset. It may include a temporary authorization token.
 - Valid states of a `TransferProcess` are `REQUESTED`, `STARTED`, `TERMINATED`, `COMPLETED`, and `SUSPENDED`.
 
 
-### 2. Transfer Start Message
+### 2. TransferStartMessage
 
 ![](./message/diagram/transfer-start-message.png)
 
@@ -127,14 +126,14 @@ Providers must include a `correlationId` property in the `TransferProcessMessage
 
 #### Description
 
-The _TransferStartMessage_ is sent by the provider to indicate the asset transfer has been initiated.
+The `TransferStartMessage` is sent by the provider to indicate the asset transfer has been initiated.
 
 #### Notes
 
-- The 'dataAddress' is only provided if the current transfer is a pull transfer and contains a transport-specific endpoint address for obtaining the asset. It may include a
+- The `dataAddress` is only provided if the current transfer is a pull transfer and contains a transport-specific endpoint address for obtaining the asset. It may include a
   temporary authorization token.
 
-### 3. Transfer Suspension Message
+### 3. TransferSuspensionMessage
 
 ![](./message/diagram/transfer-suspension-message.png)
 
@@ -150,9 +149,9 @@ The _TransferStartMessage_ is sent by the provider to indicate the asset transfe
 
 #### Description
 
-The _TransferSuspensionMessage_ is sent by the provider or consumer when either of them needs to temporarily suspend the data transfer.
+The `TransferSuspensionMessage` is sent by the provider or consumer when either of them needs to temporarily suspend the data transfer.
 
-### 4. Transfer Completion Message
+### 4. TransferCompletionMessage
 
 ![](./message/diagram/transfer-completion-message.png)
 
@@ -168,10 +167,10 @@ The _TransferSuspensionMessage_ is sent by the provider or consumer when either 
 
 #### Description
 
-The _TransferCompletionMessage_ is sent by the provider or consumer when asset transfer has completed. Note that some data plane implementations may optimize completion
-notification by performing it as part of its wire protocol. In those cases, a _TransferCompletionMessage_ message does not need to be sent.
+The `TransferCompletionMessage` is sent by the provider or consumer when asset transfer has completed. Note that some data plane implementations may optimize completion
+notification by performing it as part of its wire protocol. In those cases, a `TransferCompletionMessage` message does not need to be sent.
 
-### 5. Transfer Termination Message
+### 5. TransferTerminationMessage
 
 ![](./message/diagram/transfer-termination-message.png)
 
@@ -187,7 +186,7 @@ notification by performing it as part of its wire protocol. In those cases, a _T
 
 #### Description
 
-The _TransferTerminationMessage_ is sent by the provider or consumer at any point except a terminal state to indicate the data transfer process should stop and be placed in
+The `TransferTerminationMessage` is sent by the provider or consumer at any point except a terminal state to indicate the data transfer process should stop and be placed in
 a terminal state. If the termination was due to an error, the sender may include error information. 
 
 ## TransferError
@@ -202,8 +201,8 @@ a terminal state. If the termination was due to an error, the sender may include
 
 #### Description
 
-The _TransferError_ is an object returned by a consumer or provider indicating an error has occurred. It does not cause a state transition.
+The `TransferError` is an object returned by a consumer or provider indicating an error has occurred. It does not cause a state transition.
 
 #### Notes
 
-- A _TransferError_ is different to an error response. A _TransferError_ does not necessarily finish the negotiation but can continue afterwards.
+- A `TransferError` is different to an error response. A `TransferError` does not necessarily finish the negotiation but can continue afterwards.

--- a/transfer/transfer.process.protocol.md
+++ b/transfer/transfer.process.protocol.md
@@ -34,15 +34,15 @@ Asset transfers are characterized as `push` or `pull` transfers and asset data i
 
 #### Push Transfer
 
-A push transfer is when the producer data plane initiates sending of asset data to a consumer endpoint. For example, after the consumer has issued an `TransferRequestMessage,` the
-producer begins data transmission to an endpoint specified by the consumer using an agreed-upon wire protocol.
+A push transfer is when the provider data plane initiates sending of asset data to a consumer endpoint. For example, after the consumer has issued an `TransferRequestMessage,` the
+provider begins data transmission to an endpoint specified by the consumer using an agreed-upon wire protocol.
 
 << TODO: Include example diagram >>
 
 #### Pull Transfer
 
-A pull transfer is when the consumer data plane initiates retrieval of asset data from a producer endpoint. For example, after the consumer has issued an `TransferProcessStart,`
-message, the consumer requests the data from the producer-specified endpoint.
+A pull transfer is when the consumer data plane initiates retrieval of asset data from a provider endpoint. For example, after the consumer has issued an `TransferProcessStart,`
+message, the consumer requests the data from the provider-specified endpoint.
 
 << TODO: Include example diagram >>
 
@@ -57,10 +57,10 @@ non-finite data, a TP will continue indefinitely until either the consumer or pr
 The TP states are:
 
 - **REQUESTED** - An asset has been requested under an `Agreement` by the consumer and the provider has sent an ACK response.
-- **STARTED** - The asset is available for access by the consumer or the producer has begun pushing the asset to the consumer endpoint.
-- **COMPLETED** - The transfer has been completed by either the consumer or the producer.
-- **SUSPENDED** - The transfer has been suspended by the consumer or the producer.
-- **TERMINATED** - The transfer process has been terminated by the consumer or the producer.
+- **STARTED** - The asset is available for access by the consumer or the provider has begun pushing the asset to the consumer endpoint.
+- **COMPLETED** - The transfer has been completed by either the consumer or the provider.
+- **SUSPENDED** - The transfer has been suspended by the consumer or the provider.
+- **TERMINATED** - The transfer process has been terminated by the consumer or the provider.
 
 ### Transfer Process State Machine
 


### PR DESCRIPTION
GitBook is not rendering the `README` title properly as it is overwritte by the `SUMMARY.md`. Added name and version.

Resolved some incosistences. Removed a comment that was missed during the latest cleanup.