### PR TITLE
Removed potentially misleading token notes

### DIFF
--- a/catalog/catalog.binding.https.md
+++ b/catalog/catalog.binding.https.md
@@ -78,8 +78,8 @@ described by the [Catalog Protocol Specification](catalog.protocol.md).
 
 ### 3.1 Authorization
 
-A catalog service may require authorization. If the catalog service requires authorization, requests must include an HTTP `Authorization` header with a token. The contents of  
-the token are undefined by may be an OAUTH2, Web DID, or other access token type.
+A catalog service may require authorization. If the catalog service requires authorization, requests must include an HTTP `Authorization` header with a token. The semantics of
+such tokens are not part of this specification.
 
 ### 3.2 Versioning
 

--- a/catalog/catalog.protocol.md
+++ b/catalog/catalog.protocol.md
@@ -168,8 +168,7 @@ The discovery protocol adopted by a particular dataspace defines how a consumer 
 
 It is expected (although not required) that catalog services implement access control. A catalog as well as individual catalog _datasets_ may be restricted to trusted parties.
 The catalog service may require consumers to include a security token along with a `CatalogRequestMessage.` The specifics of how this is done can be found in the relevant
-catalog binding specification. In addition, this specification does not define the contents of the security token. It is expected different security mechanisms may be used such
-as [OAuth2 2.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-06) or [did:web](https://w3c-ccg.github.io/did-method-web/).
+catalog binding specification. The semantics of such tokens are not part of this specification.
 
 ### 4.4 Catalog Brokers
 

--- a/model/model.md
+++ b/model/model.md
@@ -20,8 +20,8 @@ Note that all relationships are multiplicities unless specified.
   use a _**verifiable presentation**_ generated from a _**credential**_ obtained from a third-party issuer. A participant agent may also use an _**ID token**_ issued by a
   third-party identity provider. Note that a participant agent is a logical construct and does not necessarily correspond to a single runtime process.
 - An `Identity Provider` is a trust anchor that generates `ID tokens` used to verify the identity of a `Participant Agent`. Multiple identity providers may operate in
-  a dataspace. The identity standard used by a provider is not defined but could be, for example, _OAuth2_ or _Decentralized Identifiers using did:web_. An identity provider may be a third-party
-  or a participant itself (for example, in the case of decentralized identifiers).
+  a dataspace. The types and semantics of ID tokens are not part of this specification. An identity provider may be a third-party or a participant itself (for example, in the case
+  of decentralized identifiers).
 - A `Credential Issuer` issues _verifiable credentials_ used by participant agents to allow access to assets and verify usage control.
 
 The diagram below depicts the relationships between `ParticipantAgent` types:

--- a/negotiation/contract.negotiation.binding.https.md
+++ b/negotiation/contract.negotiation.binding.https.md
@@ -33,8 +33,8 @@ an HTTP code 400 (Bad Request) with an `ContractNegotiationError` in the respons
 
 ### 2.3 Authorization
 
-All requests should use the `Authorizartion` header to include authorization data as specified by an authorization protocol such as [OAuth2](https://www.rfc-editor.org/rfc/rfc6749)
-. The `Authorization` HTTP header is optional if the connector does not require authorization. This specification does not mandate the use of a particular authorization standard.
+All requests should use the `Authorizartion` header to include an authorization token. The semantics of such tokens are not part of this specification. The `Authorization` HTTP
+header is optional if the connector does not require authorization.
 
 ### 2.4 The provider `negotiations` resource
 

--- a/transfer/transfer.process.binding.https.md
+++ b/transfer/transfer.process.binding.https.md
@@ -33,8 +33,8 @@ an HTTP code 400 (Bad Request) with an `TransferError` in the response body.
 
 ### 2.3 Authorization
 
-All requests should use the `Authorizartion` header to include authorization data as specified by an authorization protocol such as [OAuth2](https://www.rfc-editor.org/rfc/rfc6749)
-. The `Authorization` HTTP header is optional if the connector does not require authorization. This specification does not mandate the use of a particular authorization standard.
+All requests should use the `Authorizartion` header to include an authorization token. The semantics of such tokens are not part of this specification. The `Authorization` HTTP
+header is optional if the connector does not require authorization.
 
 ### 2.4 The provider `transfers` resource
 


### PR DESCRIPTION
As discussed in our last meeting, this PR removes problematic technology-specific notes that should not be part of the specification.
This "replaces" the contents of #53.