### PR TITLE
fix: rename CatalogRequest leftovers to CatalogRequestMessage

### DIFF
--- a/catalog/catalog.binding.https.md
+++ b/catalog/catalog.binding.https.md
@@ -37,7 +37,7 @@ Authorization: ...
 
 {
   "@context":  "https://w3id.org/dspace/v0.8/context.json",
-  "@type": "dspace:CatalogRequest",
+  "@type": "dspace:CatalogRequestMessage",
   "dspace:filter": {}
 }
 ```
@@ -141,7 +141,7 @@ Authorization: ...
 
 {
   "@context":  "https://w3id.org/dspace/v0.8/context.json",
-  "@type": "dspace:CatalogRequest"
+  "@type": "dspace:CatalogRequestMessage"
   "@id: "..."
   "dspace:callbackAddress": "https://example.com/endpoint"
 }


### PR DESCRIPTION
according to
https://github.com/International-Data-Spaces-Association/ids-specification/blob/main/catalog/message/schema/catalog-request-message-schema.json it should be CatalogRequestMessage instead of CatalogRequest