### PR TITLE
chore: add http endpoint for provider initiated CN

### DIFF
--- a/negotiation/contract.negotiation.binding.https.md
+++ b/negotiation/contract.negotiation.binding.https.md
@@ -187,11 +187,12 @@ All callback paths are relative to the `callbackAddress` base URL specified in t
 the `callbackAddress` is specified as `https://connector.consumer/callback` and a callback path binding is `negotiations/:id/offers`, the resolved URL will
 be `https://connector.consumer.com/callback/negotiations/:id/offers`.
 
-### 3.2 The consumer negotiations/offers resource
+### 3.2 The consumer `negotiations/offers` resource
 
 #### 3.2.1 POST
 
-A contract offer is started and placed in the REQUESTED state when a consumer POSTs a ContractOfferMessage to negotiations/offers:
+A contract offer is started and placed in the `OFFERED` state when a provider POSTs a
+[ContractOfferMessage](./message/contract-offer-message.json) to `negotiations/offers`:
 
 ```
 POST https://connector.provider.com/negotiations/offers
@@ -203,18 +204,22 @@ Authorization: ...
   "@type": "dspace:ContractOfferMessage"
   "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
   "dspace:dataset": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
-  "dspace:offerId": "urn:uuid:2828282:3dd1add8-4d2d-569e-d634-8394a8836a88",
+  "dspace:offer": {
+    "@type": "odrl:Offer",
+    "@id": "...",
+    "target": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88"
+  }
   "dspace:callbackAddress": "https://..."
 }
 ```
 
 The callbackAddress property specifies the base endpoint URL where the client receives messages associated with the contract negotiation. Support for the HTTPS scheme is required. Implementations may optionally support other URL schemes.
 
-Callback messages will be sent to paths under the base URL as described by this specification. Note that provider connectors should properly handle the cases where a trailing / is included with or absent from the callbackAddress when resolving full URL.
+Callback messages will be sent to paths under the base URL as described by this specification. Note that consumer connectors should properly handle the cases where a trailing / is included with or absent from the callbackAddress when resolving full URL.
 
 The @id is the correlation id that will be used for callback messages.
 
-The provider connector must return an HTTP 201 (Created) response with the location header set to the location of the contract negotiation and a body containing the ContractNegotiation message:
+The consumer connector must return an HTTP 201 (Created) response with the location header set to the location of the contract negotiation and a body containing the ContractNegotiation message:
 
 ```
 Location: /negotiations/urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3
@@ -223,7 +228,7 @@ Location: /negotiations/urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3
   "@context": "https://w3id.org/dspace/v0.8/context.json",
   "@type": "dspace:ContractNegotiation"
   "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
-  "dspace:state" :"REQUESTED"
+  "dspace:state" :"OFFERED"
 }
 ```
 

--- a/negotiation/contract.negotiation.binding.https.md
+++ b/negotiation/contract.negotiation.binding.https.md
@@ -206,6 +206,7 @@ Authorization: ...
   "dspace:offerId": "urn:uuid:2828282:3dd1add8-4d2d-569e-d634-8394a8836a88",
   "dspace:callbackAddress": "https://..."
 }
+
 The callbackAddress property specifies the base endpoint URL where the client receives messages associated with the contract negotiation. Support for the HTTPS scheme is required. Implementations may optionally support other URL schemes.
 
 Callback messages will be sent to paths under the base URL as described by this specification. Note that provider connectors should properly handle the cases where a trailing / is included with or absent from the callbackAddress when resolving full URL.
@@ -222,6 +223,7 @@ Location: /negotiations/urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3
   "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
   "dspace:state" :"REQUESTED"
 }
+
 Note that if the location header is not an absolute URL, it must resolve to an address that is relative to the base address of the Offer.
 
 ### 3.3 The consumer `negotiations/:id/offers` resource

--- a/negotiation/contract.negotiation.binding.https.md
+++ b/negotiation/contract.negotiation.binding.https.md
@@ -191,21 +191,22 @@ be `https://connector.consumer.com/callback/negotiations/:id/offers`.
 
 #### 3.2.1 POST
 
-A contract offer is started and placed in the REQUESTED state when a consumer POSTs a ContractOfferMessageto negotiations/offers:
+A contract offer is started and placed in the REQUESTED state when a consumer POSTs a ContractOfferMessage to negotiations/offers:
 
-
+```
 POST https://connector.provider.com/negotiations/offers
 
 Authorization: ...
 
 {
   "@context": "https://w3id.org/dspace/v0.8/context.json",
-  "@type": "dspace:ContractOffer"
+  "@type": "dspace:ContractOfferMessage"
   "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
   "dspace:dataset": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
   "dspace:offerId": "urn:uuid:2828282:3dd1add8-4d2d-569e-d634-8394a8836a88",
   "dspace:callbackAddress": "https://..."
 }
+```
 
 The callbackAddress property specifies the base endpoint URL where the client receives messages associated with the contract negotiation. Support for the HTTPS scheme is required. Implementations may optionally support other URL schemes.
 
@@ -215,6 +216,7 @@ The @id is the correlation id that will be used for callback messages.
 
 The provider connector must return an HTTP 201 (Created) response with the location header set to the location of the contract negotiation and a body containing the ContractNegotiation message:
 
+```
 Location: /negotiations/urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3
 
 {
@@ -223,6 +225,7 @@ Location: /negotiations/urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3
   "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
   "dspace:state" :"REQUESTED"
 }
+```
 
 Note that if the location header is not an absolute URL, it must resolve to an address that is relative to the base address of the Offer.
 

--- a/negotiation/contract.negotiation.binding.https.md
+++ b/negotiation/contract.negotiation.binding.https.md
@@ -187,9 +187,46 @@ All callback paths are relative to the `callbackAddress` base URL specified in t
 the `callbackAddress` is specified as `https://connector.consumer/callback` and a callback path binding is `negotiations/:id/offers`, the resolved URL will
 be `https://connector.consumer.com/callback/negotiations/:id/offers`.
 
-### 3.2 The consumer `negotiations/:id/offers` resource
+### 3.2 The consumer negotiations/offers resource
 
 #### 3.2.1 POST
+
+A contract offer is started and placed in the REQUESTED state when a consumer POSTs a ContractOfferMessageto negotiations/offers:
+
+
+POST https://connector.provider.com/negotiations/offers
+
+Authorization: ...
+
+{
+  "@context": "https://w3id.org/dspace/v0.8/context.json",
+  "@type": "dspace:ContractOffer"
+  "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
+  "dspace:dataset": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
+  "dspace:offerId": "urn:uuid:2828282:3dd1add8-4d2d-569e-d634-8394a8836a88",
+  "dspace:callbackAddress": "https://..."
+}
+The callbackAddress property specifies the base endpoint URL where the client receives messages associated with the contract negotiation. Support for the HTTPS scheme is required. Implementations may optionally support other URL schemes.
+
+Callback messages will be sent to paths under the base URL as described by this specification. Note that provider connectors should properly handle the cases where a trailing / is included with or absent from the callbackAddress when resolving full URL.
+
+The @id is the correlation id that will be used for callback messages.
+
+The provider connector must return an HTTP 201 (Created) response with the location header set to the location of the contract negotiation and a body containing the ContractNegotiation message:
+
+Location: /negotiations/urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3
+
+{
+  "@context": "https://w3id.org/dspace/v0.8/context.json",
+  "@type": "dspace:ContractNegotiation"
+  "@id": "urn:uuid:dcbf434c-eacf-4582-9a02-f8dd50120fd3",
+  "dspace:state" :"REQUESTED"
+}
+Note that if the location header is not an absolute URL, it must resolve to an address that is relative to the base address of the Offer.
+
+### 3.3 The consumer `negotiations/:id/offers` resource
+
+#### 3.3.1 POST
 
 A provider may make an offer by POSTing a [ContractOfferMessage](./message/contract-offer-message.json) to the `negotiations/:id/offers` callback:
 
@@ -213,9 +250,9 @@ Authorization: ...
 If the message is successfully processed, the consumer provider connector must return an HTTP 200 (OK) response. The response body is not specified and clients are not required to
 process it.
 
-### 3.3 The consumer `negotiations/:id/agreement` resource
+### 3.4 The consumer `negotiations/:id/agreement` resource
 
-#### 3.3.1 POST
+#### 3.4.1 POST
 
 The provider connector can POST a [ContractAgreementMessage](./message/contract-agreement-message.json) to the `negotiations/:id/agreement` callback to create an agreement. If the
 negotiation state is successfully transitioned, the consumer must return HTTP code 200 (OK). The response body is not specified and clients are not required to process it.
@@ -239,17 +276,17 @@ Authorization: ...
 }
 ```
 
-### 3.4 The consumer `negotiations/:id/events` resource
+### 3.5 The consumer `negotiations/:id/events` resource
 
-#### 3.4.1 POST
+#### 3.5.1 POST
 
 A provider can POST a [ContractNegotiationEventMessage](./message/contract-negotiation-event-message.json) to the `negotiations/:id/events` callback with an `eventType`
 of `FINALIZED` to finalize a contract agreement. If the negotiation state is successfully transitioned, the consumer must return HTTP code 200 (OK). The response body is not
 specified and clients are not required to process it. 
 
-### 3.5 The consumer `negotiations/:id/termination` resource
+### 3.6 The consumer `negotiations/:id/termination` resource
 
-#### 3.5.1 POST
+#### 3.6.1 POST
 
 The provider connector can POST a [ContractNegotiationTerminationMessage](./message/contract-negotiation-termination-message.json) to terminate a negotiation. If the negotiation
 state is successfully transitioned, the consumer must return HTTP code 200 (OK). The response body is not specified and clients are not required to process it.

--- a/negotiation/contract.negotiation.protocol.md
+++ b/negotiation/contract.negotiation.protocol.md
@@ -100,6 +100,9 @@ The `ContractRequestMessage` is sent by a consumer to initiate a contract negoti
 
 The `ContractOfferMessage` is sent by a provider to initiate a contract negotiation.
 
+#### Notes
+
+- The dataset id is not required but can be included when the provider initiates a contract negotiation.
 
 ### 3. ContractAgreementMessage
 


### PR DESCRIPTION
Closes #129

Adds `dspace: dataset` to the JSON example as a provider needs to hint the consumer to a dataset that the initial contract offer refers to. Is this how we want to handle this or should thecontract offer then contain the dataset as an object?