### PR TITLE
chore: update title of GitBook's landing page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-* [Dataspace Protocol v0.8](./README.md)
+* [Dataspace Protocol - Working Draft](./README.md)
 * [Terminology](./model/terminology.md)
 * [Information Model](./model/model.md)
 


### PR DESCRIPTION
We changed the title of the `README` but not the one that is rendered in GitBook.