### PR TITLE
feat: Adds a well-known proof metadata endpoint description to the catalog specifications

### DIFF
--- a/catalog/catalog.binding.https.md
+++ b/catalog/catalog.binding.https.md
@@ -138,6 +138,9 @@ path hierarchy:
 
 The contents of the response is a JSON object defined by individual trust specifications and not defined here.
 
+Note that if multiple connectors are hosted under the same base URL, a path segment appended to the base well-known URL can be used, for example,
+`https://example.com/.well-known/dspace-trust/connector1.`
+
 ## 5 Notes
 
 ### 5.1 Asynchronous Interactions

--- a/catalog/catalog.binding.https.md
+++ b/catalog/catalog.binding.https.md
@@ -128,9 +128,19 @@ Link: <https://provider.com/catalog?page=2&per_page=100>; rel="previous"
 Catalog services MAY compress responses to a catalog request by setting the `Content-Encoding` header to `gzip` as described in
 the [HTTP 1.1 Specification](https://www.rfc-editor.org/rfc/rfc9110.html#name-gzip-coding).
 
-## 4 Notes
+## 4 The Well-Known Proof Metadata Endpoint
 
-### 4.1 Asynchronous Interactions
+When an implementation supports protected _datasets_, it may offer a proof metadata endpoint clients can use to determine proof requirements. If the implementation
+offers a proof data endpoint, it must use the `dspace-trust` [Well-Known Uniform Resource Identifier](https://www.rfc-editor.org/rfc/rfc8615.html) at the top of the 
+path hierarchy:
+
+`/.well-known/dspace-trust`
+
+The contents of the response is a JSON object defined by individual trust specifications and not defined here.
+
+## 5 Notes
+
+### 5.1 Asynchronous Interactions
 
 We may want to specify optional support for asynchronous callbacks for the catalog response. This would require adding a `callbackAddress` property and an `@id` to the request:
 

--- a/catalog/catalog.protocol.md
+++ b/catalog/catalog.protocol.md
@@ -183,6 +183,13 @@ It is expected (although not required) that catalog services implement access co
 The catalog service may require consumers to include a security token along with a `CatalogRequestMessage.` The specifics of how this is done can be found in the relevant
 catalog binding specification. The semantics of such tokens are not part of this specification.
 
+#### 4.3.1 The Proof Metadata Endpoint
+
+When a catalog contains protected _datasets_ the provider has two options: include all _datasets_ in the catalog response and restrict access when a contract is negotiated; 
+or, require one or more proofs when the catalog request is made and filter the _datasets_ accordingly. The latter option requires a mechanism for clients to discover 
+the type of proofs that may be presented at request time. The specifics of proof types and presenting a proof during a catalog request is outside the scope of the 
+Dataspace Specifications. However, binding specifications should define a proof data endpoint for obtaining this information.  
+
 ### 4.4 Catalog Brokers
 
 A dataspace may include _**catalog brokers**_. A catalog broker is a consumer that has trusted access to 1..N upstream catalog services and advertises their respective catalogs as

--- a/catalog/catalog.protocol.md
+++ b/catalog/catalog.protocol.md
@@ -188,7 +188,7 @@ catalog binding specification. The semantics of such tokens are not part of this
 When a catalog contains protected _datasets_ the provider has two options: include all _datasets_ in the catalog response and restrict access when a contract is negotiated; 
 or, require one or more proofs when the catalog request is made and filter the _datasets_ accordingly. The latter option requires a mechanism for clients to discover 
 the type of proofs that may be presented at request time. The specifics of proof types and presenting a proof during a catalog request is outside the scope of the 
-Dataspace Specifications. However, binding specifications should define a proof data endpoint for obtaining this information.  
+Dataspace Protocol Specifications. However, binding specifications should define a proof data endpoint for obtaining this information.  
 
 ### 4.4 Catalog Brokers
 


### PR DESCRIPTION
As described in #161, this PR adds a description of the proof metadata endpoint using a [Well-Known Uniform Resource Identifiers](https://www.rfc-editor.org/rfc/rfc8615.html) to the Catalog Protocol and Binding specifications.


# Linked Issue(s)

Closes #161 