### PR TITLE
chore: align asset/dataset terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ __*dataspace*__.
 
 ## Introduction
 
-Sharing data between autonomous entities requires the provision of metadata to facilitate the transfer of assets by making use of a data transfer (or application layer) protocol.
+Sharing data between autonomous entities requires the provision of metadata to facilitate the transfer of datasets by making use of a data transfer (or application layer) protocol.
 The __Dataspace Protocol__ defines how this metadata is provisioned:
 
-1. How data assets are deployed as [DCAT Catalogs](https://www.w3.org/TR/vocab-dcat-3/) and usage control is expressed as [ODRL Policies](https://www.w3.org/TR/odrl-model/).
+1. How data datasets are deployed as [DCAT Catalogs](https://www.w3.org/TR/vocab-dcat-3/) and usage control is expressed as [ODRL Policies](https://www.w3.org/TR/odrl-model/).
 2. How contract agreements that govern data usage are syntactically expressed and electronically negotiated.
-3. How data assets are accessed using data transfer protocols.
+3. How datasets are accessed using data transfer protocols.
 
 These specifications build on protocols located in the [ISO OSI   model (ISO/IEC 7498-1:1994)](https://www.iso.org/standard/20269.html) layers, like HTTPS.
 The purpose of this specification is to define interactions between systems independent of such protocols, but describing how to implement it in an unambiguous and extensible way.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ __*dataspace*__.
 Sharing data between autonomous entities requires the provision of metadata to facilitate the transfer of datasets by making use of a data transfer (or application layer) protocol.
 The __Dataspace Protocol__ defines how this metadata is provisioned:
 
-1. How data datasets are deployed as [DCAT Catalogs](https://www.w3.org/TR/vocab-dcat-3/) and usage control is expressed as [ODRL Policies](https://www.w3.org/TR/odrl-model/).
+1. How datasets are deployed as [DCAT Catalogs](https://www.w3.org/TR/vocab-dcat-3/) and usage control is expressed as [ODRL Policies](https://www.w3.org/TR/odrl-model/).
 2. How contract agreements that govern data usage are syntactically expressed and electronically negotiated.
 3. How datasets are accessed using data transfer protocols.
 

--- a/catalog/catalog.protocol.md
+++ b/catalog/catalog.protocol.md
@@ -6,9 +6,9 @@ This document outlines the catalog protocol. The following terms are used:
 
 - A _**message type**_ defines the structure of a _message_.
 - A _**message**_  is an instantiation of a _message type_.
-- A _**catalog**_ is a [DCAT catalog](https://www.w3.org/TR/vocab-dcat-3/) offered by a _provider_
-- a _**catalog service**_ is a provider participant agent that advertises offered assets
-- A _**consumer**_ is a participant agent that requests access to an offered asset.
+- A _**catalog**_ is a [DCAT catalog](https://www.w3.org/TR/vocab-dcat-3/) offered by a _provider_.
+- a _**catalog service**_ is a provider participant agent that advertises offered datasets.
+- A _**consumer**_ is a participant agent that requests access to an offered datasets.
 
 The catalog protocol defines a how a `Catalog` is requested from a catalog service by a consumer using an abstract message exchange format. The concrete message exchange wire
 format is defined in binding specifications.
@@ -56,7 +56,7 @@ be defined in the relevant catalog binding specification.
 
 #### Description
 
-The catalog contains all [Asset Entries](#31-asset-entry) which the requester shall see.
+The catalog contains all [Datasets](#31-dataset) which the requester shall see.
 
 
 ### 2.3 CatalogError
@@ -112,24 +112,24 @@ The catalog service may require an authorization token. Details for including th
 
 This section describes how the IDS Information Model maps to DCAT resources.
 
-### 3.1 Asset Entry
+### 3.1 Dataset
 
-An `Asset Entry` is a [DCAT Dataset](https://www.w3.org/TR/vocab-dcat-3/#Class:Dataset) with the following attributes:
+A `Dataset` is a [DCAT Dataset](https://www.w3.org/TR/vocab-dcat-3/#Class:Dataset) with the following attributes:
 
 #### 3.1.1 odrl:hasPolicy
 
-An asset entry Dataset must have 1..N `hasPolicy` attributes that contain an ODRL `Offer` defining the usage control policy associated with the asset. Offers must NOT contain any
-target attributes. The target of an offer is the asset associated with the containing asset entry.
+A `Dataset` must have 1..N `hasPolicy` attributes that contain an ODRL `Offer` defining the usage control policy associated with the dataset. Offers must NOT contain any
+target attributes. The target of an offer is the associated dataset.
 
-> Note: As `odrl:hasPolicy rdfs:domain odrl:Asset` and `AssetEntry isA dcat:Dataset`, each `Asset Entry` is also an `odrl:Asset` from an ODRL perspective.
+> Note: As `odrl:hasPolicy rdfs:domain odrl:Asset` and `dspace:Dataset isA dcat:Dataset`, each `Dataset` is also an `odrl:Asset` from an ODRL perspective.
 
 ### 3.2 Distributions
 
-An asset may contain 0..N [DCAT Distributions](https://www.w3.org/TR/vocab-dcat-3/#Class:Distribution). Each distribution must have at least one `DataService` which specifies where
-the distribution is obtained. Specifically, a `DataService` specifies the endpoint for initiating a `ContractNegotiation` and `AssetTransfer`.
+A dataset may contain 0..N [DCAT Distributions](https://www.w3.org/TR/vocab-dcat-3/#Class:Distribution). Each distribution must have at least one `DataService` which specifies where
+the distribution is obtained. Specifically, a `DataService` specifies the endpoint for initiating a `ContractNegotiation` and `TransferProcess`.
 
-A Distribution may have 0..N `hasPolicy` attributes that contain an ODRL `Offer` defining the usage control policy associated with the asset and this explicit `Distribution`.
-Offers must NOT contain any target attributes. The target of an offer is the asset entry that contains the distribution.
+A Distribution may have 0..N `hasPolicy` attributes that contain an ODRL `Offer` defining the usage control policy associated with the dataset and this explicit `Distribution`.
+Offers must NOT contain any target attributes. The target of an offer is the dataset that contains the distribution.
 
 Support for `hasPolicy` attributes on a `Distribution` is optional. Implementations may choose not to support this feature, in which case they should return an appropriate error
 message to clients.

--- a/catalog/catalog.protocol.md
+++ b/catalog/catalog.protocol.md
@@ -121,7 +121,7 @@ A `Dataset` is a [DCAT Dataset](https://www.w3.org/TR/vocab-dcat-3/#Class:Datase
 A `Dataset` must have 1..N `hasPolicy` attributes that contain an ODRL `Offer` defining the usage control policy associated with the dataset. Offers must NOT contain any
 target attributes. The target of an offer is the associated dataset.
 
-> Note: As `odrl:hasPolicy rdfs:domain odrl:Asset` and `dspace:Dataset isA dcat:Dataset`, each `Dataset` is also an `odrl:Asset` from an ODRL perspective.
+> Note: As `odrl:hasPolicy rdfs:domain odrl:Asset`, each `Dataset` is also an `odrl:Asset` from an ODRL perspective.
 
 ### 3.2 Distributions
 

--- a/catalog/message/example/dcat.distribution.example.json
+++ b/catalog/message/example/dcat.distribution.example.json
@@ -2,15 +2,15 @@
     "@context":  "https://w3id.org/dspace/v0.8/context.json",
     "@id": "http://provider.com/catalog1/dataset1/",
     "@type": "dcat:Dataset",
-    "dct:title": "IDS Dataset #1",
+    "dct:title": "Dataset #1",
     "dct:description": [
       {
         "@language": "en",
-        "@value": "This is the number 1 data asset of the IDS. The consumer must be a TRUST_PLUS certified connector."
+        "@value": "This is the number 1 dataset. The consumer must be a TRUST_PLUS certified connector."
       },
       {
         "@language": "de",
-        "@value": "Dies ist das Nummer 1 Data Asset im IDS. Der Consumer muss ein TRUST_PLUS zertifizierter Connector sein."
+        "@value": "Dies ist das Nummer 1 dataset. Der Consumer muss ein TRUST_PLUS zertifizierter Connector sein."
       }
     ],
     "dcat:keyword": [

--- a/catalog/message/example/dcat.distribution.example.option1.json
+++ b/catalog/message/example/dcat.distribution.example.option1.json
@@ -2,20 +2,19 @@
   "@context": "https://w3id.org/dspace/v0.8/context.json",
   "@id": "http://provider.com/catalog1/dataset1/",
   "@type": "dcat:Dataset",
-  "dct:title": "IDS Dataset Collection",
+  "dct:title": "Dataset Collection",
   "dct:description": [
     {
       "@language": "en",
-      "@value": "This dataset includes all assets which identifiers comply to the pattern 'urn:guid:[A-F0-9]{8}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{12}'. A download via a S3 transfer costs 5 EUR, while the HTTP_REST transfer option costs only 2 EUR. The consumer must be a TRUST_PLUS certfified connector. No further distribution is allowed."
+      "@value": "This dataset includes all datasets which identifiers comply to the pattern 'urn:guid:[A-F0-9]{8}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{12}'. A download via a S3 transfer costs 5 EUR, while the HTTP_REST transfer option costs only 2 EUR. The consumer must be a TRUST_PLUS certfified connector. No further distribution is allowed."
     },
     {
       "@language": "de",
-      "@value": "Dieses Dataset bezeichnet alle Assets, deren Identifier dem Pattern 'urn:guid:[A-F0-9]{8}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{12}' folgen. Ein Transfer via S3 kostet etwa 5 Euro, wohingegen der Transfer via HTTP_RESt nur mit etwa 2 Euro zu Buche schlägt. Der Consumer muss ein TRUST_PLUS zertifizierter Connetor sein. Eine Weiterverbreitung ist nicht gestattet."
+      "@value": "Dieses Dataset bezeichnet alle Datasets, deren Identifier dem Pattern 'urn:guid:[A-F0-9]{8}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{12}' folgen. Ein Transfer via S3 kostet etwa 5 Euro, wohingegen der Transfer via HTTP_RESt nur mit etwa 2 Euro zu Buche schlägt. Der Consumer muss ein TRUST_PLUS zertifizierter Connetor sein. Eine Weiterverbreitung ist nicht gestattet."
     }
   ],
   "dcat:keyword": [
     "data space",
-    "data asset",
     "dcat dataset",
     "collection"
   ],

--- a/catalog/message/example/dcat.distribution.example.option2.json
+++ b/catalog/message/example/dcat.distribution.example.option2.json
@@ -2,20 +2,19 @@
     "@context":  "https://w3id.org/dspace/v0.8/context.json",
     "@id": "http://provider.com/catalog1/dataset1/",
     "@type": "dcat:Dataset",
-    "dct:title": "IDS Dataset Collection",
+    "dct:title": "Dataset Collection",
     "dct:description": [
       {
         "@language": "en",
-        "@value": "This dataset includes all assets which identifiers comply to the pattern 'urn\\:guid\\:[A-F0-9]{8}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{12}'. A download via an S3 transfer costs 5 EUR, while the HTTP_REST transfer option costs only 2 EUR. The consumer must be a TRUST_PLUS certfified connector. No further distribution is allowed."
+        "@value": "This dataset includes all datasets which identifiers comply to the pattern 'urn\\:guid\\:[A-F0-9]{8}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{12}'. A download via an S3 transfer costs 5 EUR, while the HTTP_REST transfer option costs only 2 EUR. The consumer must be a TRUST_PLUS certfified connector. No further distribution is allowed."
       },
       {
         "@language": "de",
-        "@value": "Dieses Dataset bezeichnet alle Assets, deren Identifier dem Pattern 'urn:guid:[A-F0-9]{8}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{12}' folgen. Ein Transfer via S3 kostet etwa 5 Euro, wohingegen der Transfer via HTTP_RESt nur mit etwa 2 Euro zu Buche schlägt.. Der Consumer muss ein TRUST_PLUS zertifizierter Connetor sein. Eine Weiterverbreitung ist nicht gestattet."
+        "@value": "Dieses Dataset bezeichnet alle Datasets, deren Identifier dem Pattern 'urn:guid:[A-F0-9]{8}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{4}\\-[A-F0-9]{12}' folgen. Ein Transfer via S3 kostet etwa 5 Euro, wohingegen der Transfer via HTTP_RESt nur mit etwa 2 Euro zu Buche schlägt.. Der Consumer muss ein TRUST_PLUS zertifizierter Connetor sein. Eine Weiterverbreitung ist nicht gestattet."
       }
     ],
     "dcat:keyword": [
       "data space",
-      "data asset",
       "dcat dataset",
       "collection"
     ],

--- a/model/model.md
+++ b/model/model.md
@@ -31,7 +31,7 @@ The diagram below depicts the relationships between `ParticipantAgent` types:
 - A `CatalogService` is a `Participant Agent` that makes a [DCAT Catalog](https://www.w3.org/TR/vocab-dcat-3/#Class:Catalog) available to other participants.
 - A `Catalog` contains one or more `Datasets`, which are [DCAT Datasets](https://www.w3.org/TR/vocab-dcat-3/#Class:Dataset). A `Catalog` also contains **_at least one_**
   [DCAT DataService](https://www.w3.org/TR/vocab-dcat-3/#Class:Data_Service) that references a `Connector` where datasets may be obtained.
-- An `Dataset` has **one** `Offer`, which is an [ODRL Offer](https://www.w3.org/TR/odrl-model/#policy-offer) describing the _usage control policy_ associated with the dataset.
+- A `Dataset` has **one** `Offer`, which is an [ODRL Offer](https://www.w3.org/TR/odrl-model/#policy-offer) describing the _usage control policy_ associated with the dataset.
 - A `Connector` is a `Participant Agent` that performs `Contract Negotiation` and `Transfer Process` operations with another connector. An outcome of a `ContractNegotiation` may
   be the production of an `Agreement`, which is an [ODRL Agreement](https://www.w3.org/TR/odrl-model/#policy-agreement) defining the _usage control policy_ agreed to for a dataset.
 

--- a/model/model.md
+++ b/model/model.md
@@ -16,24 +16,24 @@ Note that all relationships are multiplicities unless specified.
   Dataspace Authority may require participants to obtain some form of business certification. A Dataspace authority may also impose technical requirements such as support for the
   technical enforcement of specific usage policies.
 - A `Participant` is a member of one or more `Dataspaces`. A participant registers `Participant Agents` that perform tasks on its behalf.
-- A `Participant Agent` performs tasks such as publishing a catalog or engaging in an asset transfer. In order to accomplish these tasks, a participant agent may
+- A `Participant Agent` performs tasks such as publishing a catalog or engaging in a dataset transfer. In order to accomplish these tasks, a participant agent may
   use a _**verifiable presentation**_ generated from a _**credential**_ obtained from a third-party issuer. A participant agent may also use an _**ID token**_ issued by a
   third-party identity provider. Note that a participant agent is a logical construct and does not necessarily correspond to a single runtime process.
 - An `Identity Provider` is a trust anchor that generates `ID tokens` used to verify the identity of a `Participant Agent`. Multiple identity providers may operate in
   a dataspace. The types and semantics of ID tokens are not part of this specification. An identity provider may be a third-party or a participant itself (for example, in the case
   of decentralized identifiers).
-- A `Credential Issuer` issues _verifiable credentials_ used by participant agents to allow access to assets and verify usage control.
+- A `Credential Issuer` issues _verifiable credentials_ used by participant agents to allow access to datasets and verify usage control.
 
 The diagram below depicts the relationships between `ParticipantAgent` types:
 
 ![](./m.participant.entities.png)
 
 - A `CatalogService` is a `Participant Agent` that makes a [DCAT Catalog](https://www.w3.org/TR/vocab-dcat-3/#Class:Catalog) available to other participants.
-- A `Catalog` contains one or more `Asset Entries`, which are [DCAT Datasets](https://www.w3.org/TR/vocab-dcat-3/#Class:Dataset). A `Catalog` also contains **_at least one_**
-  [DCAT DataService](https://www.w3.org/TR/vocab-dcat-3/#Class:Data_Service) that references a `Connector` where assets may be obtained.
-- An `Asset Entry` has **one** `Offer`, which is an [ODRL Offer](https://www.w3.org/TR/odrl-model/#policy-offer) describing the _usage control policy_ associated with the asset.
-- A `Connector` is a `Participant Agent` that performs `Contract Negotiation` and `Asset Transfer` operations with another connector. An outcome of a `ContractNegotiation` may
-  be the production of an `Agreement`, which is an [ODRL Agreement](https://www.w3.org/TR/odrl-model/#policy-agreement) defining the _usage control policy_ agreed to for an asset.
+- A `Catalog` contains one or more `Datasets`, which are [DCAT Datasets](https://www.w3.org/TR/vocab-dcat-3/#Class:Dataset). A `Catalog` also contains **_at least one_**
+  [DCAT DataService](https://www.w3.org/TR/vocab-dcat-3/#Class:Data_Service) that references a `Connector` where datasets may be obtained.
+- An `Dataset` has **one** `Offer`, which is an [ODRL Offer](https://www.w3.org/TR/odrl-model/#policy-offer) describing the _usage control policy_ associated with the dataset.
+- A `Connector` is a `Participant Agent` that performs `Contract Negotiation` and `Transfer Process` operations with another connector. An outcome of a `ContractNegotiation` may
+  be the production of an `Agreement`, which is an [ODRL Agreement](https://www.w3.org/TR/odrl-model/#policy-agreement) defining the _usage control policy_ agreed to for a dataset.
 
 ## 2.2 Classes
 
@@ -48,18 +48,18 @@ The classes and definitions used in the dataspace protocol are reused from diffe
 
 A `Catalog` is a [DCAT Catalog](https://www.w3.org/TR/vocab-dcat-3/#Class:Catalog) with the following attributes:
 
-- 0..N  `Asset Entries`. Since a catalog may be dynamically generated for a request based on the requesting participant's credentials it is possible for it to contain 0 matching
-  asset entries. (DCAT PROFILE)
-- 1..N [DCAT DataService](https://www.w3.org/TR/vocab-dcat-3/#Class:Data_Service) that references a `Connector` where assets may be obtained. (DCAT PROFILE)
+- 0..N  `Datasets`. Since a catalog may be dynamically generated for a request based on the requesting participant's credentials it is possible for it to contain 0 matching
+  datasets. (DCAT PROFILE)
+- 1..N [DCAT DataService](https://www.w3.org/TR/vocab-dcat-3/#Class:Data_Service) that references a `Connector` where datasets may be obtained. (DCAT PROFILE)
 
-### 2.2.2 Asset Entry
+### 2.2.2 Dataset
 
-An `Asset Entry` is a [DCAT Dataset](https://www.w3.org/TR/vocab-dcat-3/#Class:Dataset) with the following attributes:
+A `Dataset` is a [DCAT Dataset](https://www.w3.org/TR/vocab-dcat-3/#Class:Dataset) with the following attributes:
 
-- 1..N `hasPolicy` attributes that contain an ODRL `Offer` defining the usage control policy associated with the asset. **_Offers must NOT contain any target attributes. The
-  target of an offer is the asset associated with the containing asset entry._** (ODRL PROFILE)
+- 1..N `hasPolicy` attributes that contain an ODRL `Offer` defining the usage control policy associated with the dataset. **_Offers must NOT contain any target attributes. The
+  target of an offer is the associated dataset._** (ODRL PROFILE)
 - 1..N [DCAT Distributions](https://www.w3.org/TR/vocab-dcat-3/#Class:Distribution). Each distribution must have at least one `DataService` which specifies where the distribution
-  is obtained. Specifically, a `DataService` specifies the endpoint for initiating a `ContractNegotiation` and `AssetTransfer`. (DCAT PROFILE)
+  is obtained. Specifically, a `DataService` specifies the endpoint for initiating a `ContractNegotiation` and `TransferProcess`. (DCAT PROFILE)
 
 ### 2.2.3 Offer
 
@@ -73,5 +73,5 @@ An `Offer` is an [ODRL Offer](https://www.w3.org/TR/odrl-model/#policy-offer) wi
 
 An `Agreement` is an [ODRL Agreement](https://www.w3.org/TR/odrl-model/#policy-agreement) with the following attributes:
 
-- The `Agreement` class must include one `target` attribute that is the UUID of the asset the agreement is associated with. An agreement is therefore associated with **EXACTLY
-  ONE** asset. (ODRL PROFILE)
+- The `Agreement` class must include one `target` attribute that is the UUID of the dataset the agreement is associated with. An agreement is therefore associated with **EXACTLY
+  ONE** dataset. (ODRL PROFILE)

--- a/model/model.md
+++ b/model/model.md
@@ -31,7 +31,7 @@ The diagram below depicts the relationships between `ParticipantAgent` types:
 - A `CatalogService` is a `Participant Agent` that makes a [DCAT Catalog](https://www.w3.org/TR/vocab-dcat-3/#Class:Catalog) available to other participants.
 - A `Catalog` contains one or more `Datasets`, which are [DCAT Datasets](https://www.w3.org/TR/vocab-dcat-3/#Class:Dataset). A `Catalog` also contains **_at least one_**
   [DCAT DataService](https://www.w3.org/TR/vocab-dcat-3/#Class:Data_Service) that references a `Connector` where datasets may be obtained.
-- A `Dataset` has **one** `Offer`, which is an [ODRL Offer](https://www.w3.org/TR/odrl-model/#policy-offer) describing the _usage control policy_ associated with the dataset.
+- A `Dataset` has **_at least one_** `Offer`, which is an [ODRL Offer](https://www.w3.org/TR/odrl-model/#policy-offer) describing the _usage control policy_ associated with the dataset.
 - A `Connector` is a `Participant Agent` that performs `Contract Negotiation` and `Transfer Process` operations with another connector. An outcome of a `ContractNegotiation` may
   be the production of an `Agreement`, which is an [ODRL Agreement](https://www.w3.org/TR/odrl-model/#policy-agreement) defining the _usage control policy_ agreed to for a dataset.
 

--- a/model/terminology.md
+++ b/model/terminology.md
@@ -41,7 +41,7 @@ Data or a technical service that can be shared by a `Participant`.
 
 ## Policy
 
-A set of rules, duties, and obligations that define the terms of use for an `Dataset`.
+A set of rules, duties, and obligations that define the terms of use for a `Dataset`.
 
 ## Offer
 
@@ -69,4 +69,4 @@ A set of interactions between a provider `Connector` and consumer `Connector` th
 
 ## Dataset Transfer
 
-A set of interactions between a provider `Connector` and consumer `Connector` that give access to an `Dataset` under the terms of an `Agreement`.
+A set of interactions between a provider `Connector` and consumer `Connector` that give access to a `Dataset` under the terms of an `Agreement`.

--- a/model/terminology.md
+++ b/model/terminology.md
@@ -4,7 +4,7 @@ This and the following section defines the core concepts, entities, and relation
 
 ## Dataspace
 
-A `Dataspace` is a set of technical services that facilitate interoperable asset sharing between entities.
+A `Dataspace` is a set of technical services that facilitate interoperable `Dataset` sharing between entities.
 
 ## DataspaceAuthority
 
@@ -12,7 +12,7 @@ A `DataspaceAuthority` is an entity that manages a `Dataspace`.
 
 ## Participant
 
-A `Participant` is a `Dataspace` member that provides and/or consumes assets.
+A `Participant` is a `Dataspace` member that provides and/or consumes `Datasets`.
 
 ## ParticipantAgent
 
@@ -35,25 +35,25 @@ If a  trusted technology system is required that records and verifies those doma
 
 A `DataspaceRegistrationService` is a technology system that maintains the state of `Participants` in a `Dataspace`.
 
-## Asset
+## Dataset
 
 Data or a technical service that can be shared by a `Participant`.
 
 ## Policy
 
-A set of rules, duties, and obligations that define the terms of use for an `Asset`.
+A set of rules, duties, and obligations that define the terms of use for an `Dataset`.
 
 ## Offer
 
-A concrete `Policy` associated with a specific `Asset`.
+A concrete `Policy` associated with a specific `Dataset`.
 
 ## Agreement
 
-A concrete `Policy` associated with a specific `Asset` that has been signed by both the provider and consumer `Participants`.
+A concrete `Policy` associated with a specific `Dataset` that has been signed by both the provider and consumer `Participants`.
 
 ## Catalog
 
-A collection of entries representing `Assets` and their `Offers` that is advertised by a provider `Participant`.
+A collection of entries representing `Datasets` and their `Offers` that is advertised by a provider `Participant`.
 
 ## CatalogService
 
@@ -61,12 +61,12 @@ A `ParticipantAgent` that makes a `Catalog` accessible to `Participants`.
 
 ## Connector (DataService)
 
-A `ParticipantAgent` that produces `Agreements` and manages `Asset` sharing.
+A `ParticipantAgent` that produces `Agreements` and manages `Dataset` sharing.
 
 ## Contract Negotiation
 
 A set of interactions between a provider `Connector` and consumer `Connector` that establish an `Agreement`.
 
-## Asset Transfer
+## Dataset Transfer
 
-A set of interactions between a provider `Connector` and consumer `Connector` that give access to an `Asset` under the terms of an `Agreement`.
+A set of interactions between a provider `Connector` and consumer `Connector` that give access to an `Dataset` under the terms of an `Agreement`.

--- a/negotiation/contract.negotiation.protocol.md
+++ b/negotiation/contract.negotiation.protocol.md
@@ -8,19 +8,19 @@ This document outlines the key elements of the contract negotiation protocol. Th
 - A _**message**_  is an instantiation of a _message type_.
 - The _**contract negotiation protocol**_ is the set of allowable message type sequences and is defined as a state machine (CNP-SM).
 - A _**contract negotiation (CN)**_ is an instantiation of the CNP-SM.
-- A _**provider**_ is a participant agent that offers an asset.
-- A _**consumer**_ is a participant agent that requests access to an offered asset.
+- A _**provider**_ is a participant agent that offers a dataset.
+- A _**consumer**_ is a participant agent that requests access to an offered dataset.
 
 ## Contract Negotiation Protocol
 
-A contract negotiation (CN) involves two parties, a _provider_ that offers one or more assets under a usage contract and _consumer_ that requests assets.
+A contract negotiation (CN) involves two parties, a _provider_ that offers one or more datasets under a usage contract and _consumer_ that requests datasets.
 A CN is uniquely identified through an [IRI](https://www.w3.org/International/articles/idn-and-iri/). Each CN requires a newly generated IRI, which may not be used in a CN after a terminal state has been reached.
 A CN progresses through a series of states, which are tracked by the provider and consumer using messages. A CN transitions to a state in response to an acknowledged message from
 the counter-party. Both parties have the same state of the CN. In case the states differ, the CN is terminated and a new CN has to be initiated.
 
 The CN states are:
 
-- **REQUESTED** - A contract for an asset has been requested by the consumer based on an offer and the provider has sent an ACK response.
+- **REQUESTED** - A contract for a dataset has been requested by the consumer based on an offer and the provider has sent an ACK response.
 - **OFFERED** - The provider has sent a contract offer to the consumer and the consumer has sent an ACK response.
 - **ACCEPTED** - The consumer has accepted the latest contract offer and the provider has sent an ACK response.
 - **AGREED** - The provider has accepted the latest contract offer, sent an agreement to the consumer, and the consumer has sent an ACK response.
@@ -48,7 +48,7 @@ The CN state machine is transitioned upon receipt and acknowledgement of a messa
 - Concrete wire formats are defined by the protocol binding, e.g. HTTPS.
 - All policy types (Offer, Agreement) must contain an unique identifier in the form of a URI. GUIDs can also be used in the form of URNs, for instance following the
   pattern <urn:uuid:{GUID}>.
-- An ODRL Agreement must have a target property containing the asset id.
+- An ODRL Agreement must have a target property containing the dataset id.
 
 ### 1. ContractRequestMessage
 
@@ -177,7 +177,7 @@ A `ContractAgreementVerificationMessage` must contain a `consumerPid` and a `pro
 
 #### Description
 
-When the `ContractNegotiationEventMessage` is sent by a provider with an `eventType` property set to `FINALIZED`, a contract agreement has been finalized and the associated asset
+When the `ContractNegotiationEventMessage` is sent by a provider with an `eventType` property set to `FINALIZED`, a contract agreement has been finalized and the associated dataset
 is accessible. The state machine is transitioned to the `FINALIZED` state. Other event types may be defined in the future. A consumer responds with an error if the contract
 cannot be validated or is incorrect.
 

--- a/transfer/transfer.process.protocol.md
+++ b/transfer/transfer.process.protocol.md
@@ -8,47 +8,47 @@ This document outlines the key elements of the transfer process protocol. The fo
 - A _**message**_  is an instantiation of a _message type_.
 - The _**transfer process protocol**_ is the set of allowable message type sequences and is defined as a state machine (TP-SM).
 - A _**transfer process (TP)**_ is an instantiation of the CNP-TP.
-- A _**provider**_ is a participant agent that offers an asset.
-- A _**consumer**_ is a participant agent that requests access to an offered asset.
-- A _**Connector**_ is a `PariticipantAgent` that produces `Agreements` and manages `Asset` sharing.
-- An _**Asset**_ is data or a service a provider grants access to.
-- An _**Agreement**_ is a result of a [Contract Negotiation](../negotiation/contract.negotiation.protocol.md) and is associated with _exactly one_ `Asset`.
+- A _**provider**_ is a participant agent that offers a dataset.
+- A _**consumer**_ is a participant agent that requests access to an offered dataset.
+- A _**Connector**_ is a `PariticipantAgent` that produces `Agreements` and manages `Dataset` sharing.
+- An _**Dataset**_ is data or a service a provider grants access to.
+- An _**Agreement**_ is a result of a [Contract Negotiation](../negotiation/contract.negotiation.protocol.md) and is associated with _exactly one_ `Dataset`.
 
 ## Transfer Process Protocol
 
-A transfer process (TP) involves two parties, a _provider_ that offers one or more assets under a usage policy and _consumer_ that requests assets. A TP progresses through
+A transfer process (TP) involves two parties, a _provider_ that offers one or more datasets under a usage policy and _consumer_ that requests datasets. A TP progresses through
 a series of states, which are tracked by the provider and consumer using messages. A TP transitions to a state in response to a message from the counter-party.
 
 ### Connector Components: Control and Data Planes
 
 A TP is managed by a `Connector`. The connector consists of two logical components, a `Control Plane` and a `Data Plane`. The control plane serves as a coordinating layer that
-receives counter-party messages and manages the TP state. The data plane performs the actual transfer of asset data using a wire protocol. Both participants run control and data
+receives counter-party messages and manages the TP state. The data plane performs the actual transfer of data using a wire protocol. Both participants run control and data
 planes.
 
 It is important to note that the control and data planes are logical constructs. Implementations may choose to deploy both components within a single process or across
 heterogeneous clusters.
 
-### Asset Transfer Types
+### Dataset Transfer Types
 
-Asset transfers are characterized as `push` or `pull` transfers and asset data is either `finite` or `non-finite`. This section describes the difference between these types.
+Dataset transfers are characterized as `push` or `pull` transfers and it's data is either `finite` or `non-finite`. This section describes the difference between these types.
 
 #### Push Transfer
 
-A push transfer is when the provider data plane initiates sending of asset data to a consumer endpoint. For example, after the consumer has issued an `TransferRequestMessage,` the
+A push transfer is when the provider data plane initiates sending of data to a consumer endpoint. For example, after the consumer has issued an `TransferRequestMessage,` the
 provider begins data transmission to an endpoint specified by the consumer using an agreed-upon wire protocol.
 
 ![](./push-transfer-process.png)
 
 #### Pull Transfer
 
-A pull transfer is when the consumer data plane initiates retrieval of asset data from a provider endpoint. For example, after the provider has issued an `TransferProcessStart,`
+A pull transfer is when the consumer data plane initiates retrieval of data from a provider endpoint. For example, after the provider has issued an `TransferProcessStart,`
 message, the consumer can request the data from the provider-specified endpoint.
 
 ![](./pull-transfer-process.png)
 
-#### Finite and Non-Finite Asset Data
+#### Finite and Non-Finite Data
 
-Asset data may be `finite` or `non-finite.` Finite data is data that is defined by a finite set, for example, machine learning data or images . After finite data transmission has
+Data may be `finite` or `non-finite.` Finite data is data that is defined by a finite set, for example, machine learning data or images. After finite data transmission has
 finished, the transfer process is completed. Non-finite data is data that is defined by an infinite set or has no specified end, for example streams or an API endpoint. With
 non-finite data, a TP will continue indefinitely until either the consumer or provider explicitly terminates the transmission.
 
@@ -56,8 +56,8 @@ non-finite data, a TP will continue indefinitely until either the consumer or pr
 
 The TP states are:
 
-- **REQUESTED** - An asset has been requested under an `Agreement` by the consumer and the provider has sent an ACK response.
-- **STARTED** - The asset is available for access by the consumer or the provider has begun pushing the asset to the consumer endpoint.
+- **REQUESTED** - A dataset has been requested under an `Agreement` by the consumer and the provider has sent an ACK response.
+- **STARTED** - The dataset is available for access by the consumer or the provider has begun pushing the data to the consumer endpoint.
 - **COMPLETED** - The transfer has been completed by either the consumer or the provider.
 - **SUSPENDED** - The transfer has been suspended by the consumer or the provider.
 - **TERMINATED** - The transfer process has been terminated by the consumer or the provider.
@@ -90,7 +90,7 @@ The `TransferRequestMessage` is sent by a consumer to initiate a transfer proces
 
 - The `consumerPid` property refers to the transfer id on consumer side.
 - The `agreementId` property refers to an existing contract agreement between the consumer and provider.
-- The `dct:format` property is a format specified by a `Distribution` for the `Asset` associated with the agreement. This is generally obtained from the provider `Catalog`.
+- The `dct:format` property is a format specified by a `Distribution` for the `Dataset` associated with the agreement. This is generally obtained from the provider `Catalog`.
 - The `dataAddress` property must only be provided if the `dct:format` requires a push transfer.
 - `callbackAddress` is a URI indicating where messages to the consumer should be sent. If the address is not understood, the provider MUST return an UNRECOVERABLE error.
 
@@ -102,7 +102,7 @@ Once a transfer process have been created, all associated callback messages must
 
 Providers must include a `dspace:consumerPid` and a `dspace:providerPid` property in the `TransferProcess`.
 
-- The `dataAddress` contains a transport-specific endpoint address for pushing the asset. It may include a temporary authorization via the `dspace:endpointProperties` property.
+- The `dataAddress` contains a transport-specific endpoint address for pushing the data. It may include a temporary authorization via the `dspace:endpointProperties` property.
 - Valid states of a `TransferProcess` are `REQUESTED`, `STARTED`, `TERMINATED`, `COMPLETED`, and `SUSPENDED`.
 
 
@@ -123,11 +123,11 @@ Providers must include a `dspace:consumerPid` and a `dspace:providerPid` propert
 
 #### Description
 
-The `TransferStartMessage` is sent by the provider to indicate the asset transfer has been initiated.
+The `TransferStartMessage` is sent by the provider to indicate the dataset transfer has been initiated.
 
 #### Notes
 
-- The `dataAddress` is only provided if the current transfer is a pull transfer and contains a transport-specific endpoint address for obtaining the asset.. It may include a temporary authorization via the `dspace:endpointProperties` property.
+- The `dataAddress` is only provided if the current transfer is a pull transfer and contains a transport-specific endpoint address for obtaining the dataset. It may include a temporary authorization via the `dspace:endpointProperties` property.
 
 ### 3. TransferSuspensionMessage
 
@@ -163,7 +163,7 @@ The `TransferSuspensionMessage` is sent by the provider or consumer when either 
 
 #### Description
 
-The `TransferCompletionMessage` is sent by the provider or consumer when asset transfer has completed. Note that some data plane implementations may optimize completion
+The `TransferCompletionMessage` is sent by the provider or consumer when a dataset transfer has completed. Note that some data plane implementations may optimize completion
 notification by performing it as part of its wire protocol. In those cases, a `TransferCompletionMessage` message does not need to be sent.
 
 ### 5. TransferTerminationMessage


### PR DESCRIPTION
Closes #187 

Changed `asset` to `dataset`. Removed occurences of `IDS`.