### PR TITLE
ci: fix typo for file check workflow

### DIFF
--- a/.github/workflows/prevent-file-changes.yml
+++ b/.github/workflows/prevent-file-changes.yml
@@ -2,9 +2,8 @@ name: Prevent Changes to Release Files
 
 on:
   pull_request:
-    types: [ opened ]
-  pull_request_target:
-    types: [ opened ]
+    branches: [ main ]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   check:

--- a/.github/workflows/prevent-file-changes.yml
+++ b/.github/workflows/prevent-file-changes.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubunut-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Prevent file change
         uses: xalvarez/prevent-file-change-action@v1


### PR DESCRIPTION
Well... that's a classic: discovering a typo 10 sec after merging the PR.