### PR TITLE
Add pagination and filter changes

### DIFF
--- a/catalog/catalog.binding.https.md
+++ b/catalog/catalog.binding.https.md
@@ -60,7 +60,7 @@ Authorization: ...
 
 - The `Authorization` header is optional if the [Catalog Service](../model/terminology.md#catalog-service) does not require authorization. If present, the contents of the `Authorization` header are detailed in the [Authorization section](#13-authorization).
 
-- The `filter` property is optional. If present, the `filter` property can contain an implementation-specific filter expression or query to be executed as part of the [Catalog](../model/terminology.md#catalog) request.
+- The `filter` property is optional. If present, the `filter` property can contain an implementation-specific filter expression or query to be executed as part of the [Catalog](../model/terminology.md#catalog) request. If a filter expression is not supported by an implementation, it must return a HTTP 400 (Bad Request) response.
 
 ##### Response
 
@@ -100,10 +100,13 @@ If the request is successful, the [Catalog Service](../model/terminology.md#cata
 
 ### 3.2 Pagination
 
-A [Catalog Service](../model/terminology.md#catalog-service) may paginate the results of a [Catalog Request Message](./catalog.protocol.md#21-catalog-request-message). Pagination data is specified using [Web Linking](https://datatracker.ietf.org/doc/html/rfc5988) and the HTTP `Link` header. The `Link` header will contain URLs for navigating to previous and subsequent results. The following request sequence demonstrates pagination:
+A [Catalog Service](../model/terminology.md#catalog-service) may paginate the results of a [Catalog Request Message](./catalog.protocol.md#21-catalog-request-message). Pagination data must be specified using [Web Linking](https://datatracker.ietf.org/doc/html/rfc5988) and the HTTP `Link` header. The `Link` header will contain URLs for navigating to previous and subsequent results. Only the `next` and `previous` link relation types must be supported. 
+Note that the content and structure of the link query parameters is not defined by the current specification. 
+
+The following request sequence demonstrates pagination:
 
 ```http request
-Link: <https://provider.com/catalog?page=2&per_page=100>; rel="next"
+Link: <https://provider.com/catalog?continuationToken=f59892315ac44de8ab4bdc9014502d52>; rel="next"
 
 {
   "@context":  "https://w3id.org/dspace/v0.8/context.json",
@@ -115,8 +118,8 @@ Link: <https://provider.com/catalog?page=2&per_page=100>; rel="next"
 Second page response:
 
 ```http request
-Link: <https://provider.com/catalog?page=1&per_page=100>; rel="previous"
-Link: <https://provider.com/catalog?page=3&per_page=100>; rel="next"
+Link: <https://provider.com/catalog?continuationToken=f59892315ac44de8ab4bdc9014502d52>; rel="previous"
+Link: <https://provider.com/catalog?continuationToken=f59892315ac44de8ab4bdc9014502d52>; rel="next"
 
 {
    "@type": "dcat:Catalog",
@@ -127,7 +130,7 @@ Link: <https://provider.com/catalog?page=3&per_page=100>; rel="next"
 Last page response:
 
 ```http request
-Link: <https://provider.com/catalog?page=2&per_page=100>; rel="previous"
+Link: <https://provider.com/catalog?continuationToken=f59892315ac44de8ab4bdc9014502d52>; rel="previous"
 
 {
    "@type": "dcat:Catalog",

--- a/catalog/catalog.binding.https.md
+++ b/catalog/catalog.binding.https.md
@@ -118,7 +118,7 @@ Link: <https://provider.com/catalog?continuationToken=f59892315ac44de8ab4bdc9014
 Second page response:
 
 ```http request
-Link: <https://provider.com/catalog?continuationToken=f59892315ac44de8ab4bdc9014502d52>; rel="previous"
+Link: <https://provider.com/catalog?continuationToken=a59779015bn44de8ab4bfc9014502d53>; rel="previous"
 Link: <https://provider.com/catalog?continuationToken=f59892315ac44de8ab4bdc9014502d52>; rel="next"
 
 {
@@ -130,7 +130,7 @@ Link: <https://provider.com/catalog?continuationToken=f59892315ac44de8ab4bdc9014
 Last page response:
 
 ```http request
-Link: <https://provider.com/catalog?continuationToken=f59892315ac44de8ab4bdc9014502d52>; rel="previous"
+Link: <https://provider.com/catalog?continuationToken=bn9556075bn44de8ab4bfc9014582t76>; rel="previous"
 
 {
    "@type": "dcat:Catalog",

--- a/catalog/catalog.protocol.md
+++ b/catalog/catalog.protocol.md
@@ -101,7 +101,7 @@ All messages must be serialized in JSON-LD compact form as specified in the [JSO
 
 The Catalog Request Message is message sent by a [Consumer](../model/terminology.md#consumer) to a [Catalog Service](../model/terminology.md#catalog-service). The [Catalog Service](../model/terminology.md#catalog-service) must respond with a [Catalog](#31-ack---catalog), which is a valid instance of a [DCAT Catalog](https://www.w3.org/TR/vocab-dcat-3/#Class:Catalog).
 
-- The message may have a `filter` property which contains an implementation-specific query or filter expression type supported by the [Catalog Service](../model/terminology.md#catalog-service).
+- The message may have a `filter` property which contains an implementation-specific query or filter expression type supported by the [Catalog Service](../model/terminology.md#catalog-service). 
 
 - The [Catalog Service](../model/terminology.md#catalog-service) may require an authorization token. Details for including that token can be found in the protocol binding, e.g., [Catalog HTTPS Binding](./catalog.binding.https.md). Similarly, pagination may be defined in the protocol binding.
 


### PR DESCRIPTION
Adds the following:

- Adjust pagination to be normative and only require "next" and "previous" relations.
- Change the pagination examples to use a continuation param.
- Add Result 400 Bad Request.

Note that pagination "normative" cannot be done in the abstract protocol specification as some transports may not support (or want to support) pagination. We also should not make pagination "mandatory" since an implementation may choose not to offer it (which, for most catalogs, even large ones, is likely not necessary given support for compression technologies) or choose to perform it on every type of request. Making it "normative" means when pagination is performed, it is serialized in a certain format.

Note that I did not change the Technical Considerations section. It offers important information about the protocol design (not implementation-specific information) that is valuable to retain.

Closes #194 