### PR TITLE
Deactivate the Protection of the "releases" Folder

### DIFF
--- a/.github/workflows/prevent-file-changes.yml
+++ b/.github/workflows/prevent-file-changes.yml
@@ -2,7 +2,7 @@ name: Prevent Changes to Release Files
 
 on:
   pull_request:
-    branches: [ main ]
+    #branches: [ main ]
     types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 jobs:


### PR DESCRIPTION
https://github.com/International-Data-Spaces-Association/ids-specification/pull/264 requires an update of the files in "releases/2024-1/", which is protected by a Github Action. This PR shall temporarily remove the protection to fix the files. A following PR will then  re-enable the Action again.